### PR TITLE
Back end

### DIFF
--- a/src-tauri/src/menus/menu_builders.rs
+++ b/src-tauri/src/menus/menu_builders.rs
@@ -20,9 +20,30 @@ fn build_file_menu(app: &App<Wry>) -> Submenu<Wry> {
         .build(app)
         .unwrap();
 
+    let audio_context = app.state::<states::StateAudioContext>();
+    let output_device_registry = audio_context.output_device_registry.clone();
+
+    let output_menu = SubmenuBuilder::new(app, "Output Device")
+        .id("file-output-devices")
+        .build()
+        .unwrap();
+
+    for (i, output_device_name) in output_device_registry.list().iter().enumerate() {
+        let id = format!("file-output-device-{}", i);
+        let output_device = CheckMenuItemBuilder::new(output_device_name)
+            .id(id)
+            .checked(i == 0)
+            .build(app)
+            .unwrap();
+
+        output_menu
+            .append(&output_device)
+            .expect("Failed to add item to menu");
+    }
+
     let file_menu = SubmenuBuilder::new(app, "File")
         .id("file")
-        .item(&settings)
+        .items(&[&settings, &output_menu])
         .quit()
         .build()
         .unwrap();
@@ -56,63 +77,11 @@ fn build_project_menu(app: &App<Wry>) -> Submenu<Wry> {
     project_menu
 }
 
-fn build_device_menu(app: &App<Wry>) -> Submenu<Wry> {
-    let audio_context = app.state::<states::StateAudioContext>();
-    let input_device_registry = audio_context.input_device_registry.clone();
-    let output_device_registry = audio_context.output_device_registry.clone();
-
-    let input_menu = SubmenuBuilder::new(app, "Input Device")
-        .id("devices-input-devices")
-        .build()
-        .unwrap();
-
-    for (i, input_device_name) in input_device_registry.list().iter().enumerate() {
-        let id = format!("devices-input-{}", i);
-        let input_device = CheckMenuItemBuilder::new(input_device_name)
-            .id(id)
-            .checked(i == 0)
-            .build(app)
-            .unwrap();
-
-        input_menu
-            .append(&input_device)
-            .expect("Failed to add item to menu");
-    }
-
-    let output_menu = SubmenuBuilder::new(app, "Output Device")
-        .id("devices-output-devices")
-        .build()
-        .unwrap();
-
-    for (i, output_device_name) in output_device_registry.list().iter().enumerate() {
-        let id = format!("devices-output-{}", i);
-        let output_device = CheckMenuItemBuilder::new(output_device_name)
-            .id(id)
-            .checked(i == 0)
-            .build(app)
-            .unwrap();
-
-        output_menu
-            .append(&output_device)
-            .expect("Failed to add item to menu");
-    }
-
-    let device_menu = SubmenuBuilder::new(app, "Devices")
-        .id("devices")
-        .item(&input_menu)
-        .item(&output_menu)
-        .build()
-        .unwrap();
-
-    device_menu
-}
-
 pub fn build_menus(app: &App<Wry>) -> Menu<Wry> {
     let file_menu = build_file_menu(app);
     let project_menu = build_project_menu(app);
-    let device_menu = build_device_menu(app);
     MenuBuilder::new(app)
-        .items(&[&file_menu, &project_menu, &device_menu])
+        .items(&[&file_menu, &project_menu])
         .build()
         .unwrap()
 }
@@ -126,17 +95,12 @@ pub async fn handle_menu_events(app: &AppHandle, event: &MenuEvent) {
         "file-settings" => pages::settings_page::open_settings(app),
         "project-add-track-file" => menus::project_menu::add_track_file(app).await,
         "project-add-track-stream" => pages::select_input_stream::open_select_input_stream(app),
-        _ => {
-            if id.starts_with("devices-input") {
-                update_device_index(audio_context.input_device_index.clone(), id);
-                update_radio_group_menu(app, id);
-            } else if id.starts_with("devices-output") {
-                update_device_index(audio_context.output_device_index.clone(), id);
-                update_radio_group_menu(app, id);
-            } else {
-                eprintln!("Unknown menu item selected");
-            }
+        _ if id.starts_with("file-output-device-") => {
+            update_device_index(audio_context.output_device_index.clone(), id);
+            update_radio_group_menu(app, id);
+            // TODO update master out track
         }
+        _ => eprintln!("Unknown menu item selected"),
     }
 }
 
@@ -159,14 +123,10 @@ fn update_radio_group_menu(app: &AppHandle, id: &str) {
 }
 
 fn loop_through_sub_menus(id: &str, main_menu: MenuItemKind<Wry>) {
-    if main_menu.id().0 == "devices" {
+    if main_menu.id().0 == "file" {
         if let MenuItemKind::Submenu(device_menu) = main_menu {
             for menu_item in device_menu.items().expect("Failed to get sub menu items") {
-                if menu_item.id().0 == "devices-input-devices" && id.starts_with("devices-input") {
-                    uncheck_other_devices(id, menu_item);
-                } else if menu_item.id().0 == "devices-output-devices"
-                    && id.starts_with("devices-output")
-                {
+                if menu_item.id().0 == "file-output-devices" && id.starts_with("file-output") {
                     uncheck_other_devices(id, menu_item);
                 }
             }
@@ -175,9 +135,9 @@ fn loop_through_sub_menus(id: &str, main_menu: MenuItemKind<Wry>) {
 }
 
 fn uncheck_other_devices(id: &str, menu_item: MenuItemKind<Wry>) {
-    if let MenuItemKind::Submenu(io_devices) = menu_item {
-        for io_device in io_devices.items().expect("Failed to get menus") {
-            if let MenuItemKind::Check(device) = io_device {
+    if let MenuItemKind::Submenu(o_devices) = menu_item {
+        for o_device in o_devices.items().expect("Failed to get menus") {
+            if let MenuItemKind::Check(device) = o_device {
                 device
                     .set_checked(device.id().0 == id)
                     .expect("Failed to uncheck item");

--- a/src-tauri/src/menus/menu_builders.rs
+++ b/src-tauri/src/menus/menu_builders.rs
@@ -11,10 +11,7 @@ use tauri::{
     App, AppHandle, Manager, Wry,
 };
 
-use crate::{
-    menus, pages, states,
-    track::{self, get_track_list},
-};
+use crate::{menus, pages, states, track};
 
 fn build_file_menu(app: &App<Wry>) -> Submenu<Wry> {
     let settings = MenuItemBuilder::new("Settings")
@@ -131,7 +128,7 @@ fn update_master_output_device_track(app: &AppHandle) {
     let audio_context = app.state::<states::StateAudioContext>();
     let new_master_output_device = audio_context
         .output_device()
-        .expect("Failed to get new master output device"); // TODO change registries to store Arc<>
+        .expect("Failed to get new master output device");
     let new_output_source = track::StreamSource::new(new_master_output_device.clone());
     master_output.change_source(Box::new(new_output_source));
 }

--- a/src-tauri/src/states.rs
+++ b/src-tauri/src/states.rs
@@ -23,7 +23,7 @@ pub struct StateMixer {
 }
 
 impl StateMixer {
-    pub fn new(master_output: Device) -> Self {
+    pub fn new(master_output: Arc<Device>) -> Self {
         let mut track_list = TrackList::new();
         let master_out = Track::new(
             TrackType::MasterOut,
@@ -59,12 +59,12 @@ impl StateAudioContext {
         }
     }
 
-    pub fn input_device(&self) -> Option<&cpal::Device> {
+    pub fn input_device(&self) -> Option<Arc<cpal::Device>> {
         self.input_device_registry
             .get(self.input_device_index.load(Ordering::SeqCst))
     }
 
-    pub fn output_device(&self) -> Option<&cpal::Device> {
+    pub fn output_device(&self) -> Option<Arc<cpal::Device>> {
         self.output_device_registry
             .get(self.output_device_index.load(Ordering::SeqCst))
     }

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     fs,
-    io::{BufReader, BufWriter, StdoutLock},
+    io::{BufReader, BufWriter},
     path::PathBuf,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -50,7 +50,7 @@ pub struct StreamSource {
 }
 
 impl StreamSource {
-    pub fn new(device: cpal::Device) -> Self {
+    pub fn new(device: Arc<cpal::Device>) -> Self {
         let ring_buffer = Arc::new(Mutex::new(RingBuffer::new()));
         let ring_buffer_clone = ring_buffer.clone();
 

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -272,6 +272,10 @@ impl Track {
             solo: false,
         }
     }
+
+    pub fn change_source(&mut self, new_source: Box<dyn TrackAudioSource + Send>) {
+        self.source = new_source;
+    }
 }
 
 pub struct TrackList {

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use cpal::traits::{DeviceTrait, HostTrait};
+use std::{collections::HashMap, sync::Arc};
 
 pub struct RingBuffer {
     buffer: [f32; 48000],
@@ -55,7 +55,7 @@ impl RingBuffer {
 
 #[derive(Clone)]
 pub struct InputDeviceRegistry {
-    devices: HashMap<String, cpal::Device>,
+    devices: HashMap<String, Arc<cpal::Device>>,
 }
 
 impl InputDeviceRegistry {
@@ -63,18 +63,18 @@ impl InputDeviceRegistry {
         let mut map = HashMap::new();
         for device in host.input_devices().expect("No input devices available") {
             let name = device.name().unwrap_or_else(|_| "Unknown".into());
-            map.insert(name.clone(), device);
+            map.insert(name.clone(), Arc::new(device));
         }
 
         Self { devices: map }
     }
 
-    pub fn get_from_name(&self, name: &str) -> Option<&cpal::Device> {
-        self.devices.get(name)
+    pub fn get_from_name(&self, name: &str) -> Option<Arc<cpal::Device>> {
+        self.devices.get(name).cloned()
     }
 
-    pub fn get(&self, index: usize) -> Option<&cpal::Device> {
-        self.devices.values().nth(index)
+    pub fn get(&self, index: usize) -> Option<Arc<cpal::Device>> {
+        self.devices.values().nth(index).cloned()
     }
 
     pub fn list(&self) -> Vec<String> {
@@ -84,7 +84,7 @@ impl InputDeviceRegistry {
 
 #[derive(Clone)]
 pub struct OutputDeviceRegistry {
-    devices: HashMap<String, cpal::Device>,
+    devices: HashMap<String, Arc<cpal::Device>>,
 }
 
 impl OutputDeviceRegistry {
@@ -92,18 +92,18 @@ impl OutputDeviceRegistry {
         let mut map = HashMap::new();
         for device in host.output_devices().expect("No output devices available") {
             let name = device.name().unwrap_or_else(|_| "Unknown".into());
-            map.insert(name.clone(), device);
+            map.insert(name.clone(), Arc::new(device));
         }
 
         Self { devices: map }
     }
 
-    pub fn get_from_name(&self, name: &str) -> Option<&cpal::Device> {
-        self.devices.get(name)
+    pub fn get_from_name(&self, name: &str) -> Option<Arc<cpal::Device>> {
+        self.devices.get(name).cloned()
     }
 
-    pub fn get(&self, index: usize) -> Option<&cpal::Device> {
-        self.devices.values().nth(index)
+    pub fn get(&self, index: usize) -> Option<Arc<cpal::Device>> {
+        self.devices.values().nth(index).cloned()
     }
 
     pub fn list(&self) -> Vec<String> {


### PR DESCRIPTION
- Remove device menu and input device selection
- Move output device selection to the `File` menu
- Update Input and Output registries to use `Arc<Device>`
- Update the master out track source based on the output device source